### PR TITLE
Fix Issue "Over-specification in `h'-direction"

### DIFF
--- a/geometry.dtx
+++ b/geometry.dtx
@@ -2321,11 +2321,13 @@ the derived files: geometry.{sty,ins,drv}, geometry-samples.tex.
     \let\Gm@hscale\@undefined
     \let\Gm@width\@undefined
     \let\Gm@textwidth\@undefined
+    \Gm@hbodyfalse
   \fi
   \ifGm@vbody\else
     \let\Gm@vscale\@undefined
     \let\Gm@height\@undefined
     \let\Gm@textheight\@undefined
+    \Gm@vbodyfalse
   \fi
   }%
 %    \end{macrocode}


### PR DESCRIPTION
Hi,

\ifGm@hbody is true if either width, textwidth or hscale is set. In \Gm@clean,
those three are cleared, so I think  \ifGm@hbody should be set to false. The
same happens for the 'v' direction.

Thanks,

SurJector